### PR TITLE
typo in High-Level View page

### DIFF
--- a/high-level-view.html
+++ b/high-level-view.html
@@ -418,7 +418,7 @@ the next-state relation allows a step is a fairness condition.
 <p>
 
 A state-machine model without a fairness condition can be used to
-catch errors of <q>commision</q>, in which the system does something
+catch errors of <q>commission</q>, in which the system does something
 wrong.&nbsp; It can't be used to catch errors of <q>omission</q>, in
 which the system fails to do something.&nbsp; In practice, errors of
 commission are more numerous and harder to find than errors of

--- a/high-level-view13c2.html
+++ b/high-level-view13c2.html
@@ -418,7 +418,7 @@ the next-state relation allows a step is a fairness condition.
 <p>
 
 A state-machine model without a fairness condition can be used to
-catch errors of <q>commision</q>, in which the system does something
+catch errors of <q>commission</q>, in which the system does something
 wrong.&nbsp; It can't be used to catch errors of <q>omission</q>, in
 which the system fails to do something.&nbsp; In practice, errors of
 commission are more numerous and harder to find than errors of

--- a/high-level-view65f4.html
+++ b/high-level-view65f4.html
@@ -418,7 +418,7 @@ the next-state relation allows a step is a fairness condition.
 <p>
 
 A state-machine model without a fairness condition can be used to
-catch errors of <q>commision</q>, in which the system does something
+catch errors of <q>commission</q>, in which the system does something
 wrong.&nbsp; It can't be used to catch errors of <q>omission</q>, in
 which the system fails to do something.&nbsp; In practice, errors of
 commission are more numerous and harder to find than errors of


### PR DESCRIPTION
Hi, I believe the High-Level View page has a small typo?

Not sure if this repo is taking prs, so apologies in advance if this is the wrong place to report it